### PR TITLE
Fixing the Launch Command to allow for ECS Health Checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ COPY . .
 RUN apk --no-cache add g++ make 
 RUN gem install bundler rake && bundle install && chmod +x docker-entrypoint.sh
 
+EXPOSE 8088
+
 ENTRYPOINT ./docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,2 @@
 #!/bin/ash
-REDIS_URL=${REDIS_URL:-redis://redis:${REDIS_CUSTOM_PORT:-6379}/${REDIS_DB_NAME:-tipbot}} /usr/local/bundle/bin/rackup config.ru
-
+REDIS_URL=${REDIS_URL:-redis://redis:${REDIS_CUSTOM_PORT:-6379}/${REDIS_DB_NAME:-tipbot}} /usr/local/bundle/bin/bundle exec puma -p ${PORT:-8088}


### PR DESCRIPTION
Changing the entrypoint to launch the puma bundle as well for health checking. 